### PR TITLE
feat(sockets): frontend Socket.io client for live task updates + presence (#9)

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/app/*"]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "next": "^16.2.4",
         "react": "~19.2.0",
         "react-dom": "~19.2.0",
-        "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1",
+        "socket.io": "^4.8.3",
+        "socket.io-client": "^4.8.3",
         "uuid": "^14.0.0"
       },
       "devDependencies": {
@@ -5928,13 +5928,15 @@
       "license": "ISC"
     },
     "node_modules/socket.io": {
-      "version": "4.8.1",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "cors": "~2.8.5",
-        "debug": "~4.3.2",
+        "debug": "~4.4.1",
         "engine.io": "~6.6.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
@@ -5954,31 +5956,18 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.8.1",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.2",
+        "debug": "~4.4.1",
         "engine.io-client": "~6.6.1",
         "socket.io-parser": "~4.2.4"
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-client/node_modules/debug": {
-      "version": "4.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/socket.io-parser": {
@@ -6001,21 +5990,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/debug": {
-      "version": "4.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/socket.io/node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "next": "^16.2.4",
     "react": "~19.2.0",
     "react-dom": "~19.2.0",
-    "socket.io": "^4.8.1",
-    "socket.io-client": "^4.8.1",
+    "socket.io": "^4.8.3",
+    "socket.io-client": "^4.8.3",
     "uuid": "^14.0.0"
   },
   "devDependencies": {

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { cookies } from 'next/headers';
 import { AppFrame } from '../components/AppFrame';
 import { WorkspaceProvider } from '../lib/WorkspaceContext';
+import { SocketProvider } from '../lib/SocketContext';
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const sidebarOpenCookie = (await cookies()).get('sidebar-open')?.value;
@@ -10,7 +11,9 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   return (
     <Suspense>
       <WorkspaceProvider>
-        <AppFrame initialSidebarOpen={initialSidebarOpen}>{children}</AppFrame>
+        <SocketProvider>
+          <AppFrame initialSidebarOpen={initialSidebarOpen}>{children}</AppFrame>
+        </SocketProvider>
       </WorkspaceProvider>
     </Suspense>
   );

--- a/src/app/(app)/taskboard/page.tsx
+++ b/src/app/(app)/taskboard/page.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, startTransition, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { io } from 'socket.io-client';
 import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors, closestCorners } from '@dnd-kit/core';
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import { Draggable } from '../../components/Draggable';
@@ -15,6 +14,7 @@ import { Button } from '../../ui/Button';
 import { Icon } from '../../ui/Icon';
 import { LABELS, PEOPLE_BY_ID } from '../../data/labels';
 import { useTasks } from '../../hooks/useTasks';
+import { useBoardPresence } from '../../hooks/useBoardPresence';
 import { useWorkspace } from '../../lib/WorkspaceContext';
 import { useAuthToken } from '../../lib/auth/useAuthToken';
 import { getTeamMembers, type TeamMember } from '../../lib/api/teams';
@@ -62,11 +62,7 @@ function tasksToColumns(tasks: Task[]): Record<string, { name: string; items: Ta
   return cols;
 }
 
-//  Socket (module-level, shared) 
-
-const socket = io(process.env.NEXT_PUBLIC_SOCKET_URL);
-
-//  Inner board component (needs Suspense for useSearchParams) 
+//  Inner board component (needs Suspense for useSearchParams)
 
 function TaskBoardInner() {
   const searchParams = useSearchParams();
@@ -90,6 +86,7 @@ function TaskBoardInner() {
 
   const { boardsByTeam, user } = useWorkspace();
   const getToken = useAuthToken();
+  const onlineUsers = useBoardPresence(boardId);
 
   const currentBoard = useMemo(() => {
     for (const boards of Object.values(boardsByTeam)) {
@@ -142,6 +139,7 @@ function TaskBoardInner() {
   const doneTasks = tasks.filter(t => t.status === 'done').length;
   const progress  = tasks.length ? Math.round((doneTasks / tasks.length) * 100) : 0;
   const teamNames = teamMembers.map(m => m.name);
+  const onlineNames = onlineUsers.map(user => user.name);
   const columnOptions = Object.entries(columns).map(([id, col]) => ({
     id,
     name: col.name,
@@ -195,7 +193,8 @@ function TaskBoardInner() {
     if (!sourceColId || !targetColId) { setActiveId(null); return; }
 
     if (sourceColId !== targetColId) {
-      // Status changed — persist to backend and emit real-time event.
+      // Status changed — persist to backend; useTasks' socket listener
+      // picks up the resulting task:updated broadcast for other clients.
       // Hiding the drag overlay (setActiveId) and the optimistic status move
       // (inside updateTask) must land in the same commit — otherwise the
       // overlay disappears in an urgent render first, flashing the real card
@@ -205,7 +204,6 @@ function TaskBoardInner() {
         setActiveId(null);
         updateTask(activeTaskId, { status: newStatus });
       });
-      socket.emit('update-tasks');
     } else {
       setActiveId(null);
       // Same-column reorder isn't persisted: tasks have no position field yet,
@@ -259,6 +257,7 @@ function TaskBoardInner() {
         subtitle={`${doneTasks} of ${tasks.length} done — you're on track.`}
         progress={progress}
         teamNames={teamNames}
+        onlineNames={onlineNames}
         hasTeammates={teamMembers.length > 1}
         onNewTask={() => setCreateColumnId('header')}
         searchQuery={searchQuery}

--- a/src/app/components/BoardHeader.tsx
+++ b/src/app/components/BoardHeader.tsx
@@ -13,6 +13,7 @@ interface BoardHeaderProps {
   progress: number;      // 0–100
   teamNames: string[];
   hasTeammates?: boolean;
+  onlineNames?: string[];
   onNewTask: () => void;
   searchQuery: string;
   onSearchChange: (q: string) => void;
@@ -26,6 +27,7 @@ export function BoardHeader({
   progress,
   teamNames,
   hasTeammates = false,
+  onlineNames = [],
   onNewTask,
   searchQuery,
   onSearchChange,
@@ -80,6 +82,11 @@ export function BoardHeader({
               </Button>
               <span aria-hidden="true" className="hidden md:inline text-chalk text-[18px] font-light">|</span>
             </>
+          )}
+
+          {/* Online now */}
+          {onlineNames.length > 0 && (
+            <AvatarStack names={onlineNames} size={28} max={4} label="Online now" />
           )}
 
           {/* Team avatars */}

--- a/src/app/hooks/useBoardPresence.ts
+++ b/src/app/hooks/useBoardPresence.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSocket } from '../lib/SocketContext';
+import type { PresenceUpdatePayload, PresenceUser } from '../types/socket';
+
+// Listens for presence snapshots for a board room. Does NOT itself emit
+// join-board/leave-board — useTasks(boardId) already owns that room's
+// lifecycle, and having two hooks independently join/leave the same room
+// risks flapping membership (especially under React StrictMode's dev
+// double-invoke). Callers must use this alongside useTasks(boardId) for the
+// same board.
+export function useBoardPresence(boardId: string | null): PresenceUser[] {
+  const { socket } = useSocket();
+  const [users, setUsers] = useState<PresenceUser[]>([]);
+
+  useEffect(() => {
+    setUsers([]);
+    if (!socket || !boardId) return;
+
+    const onUpdate = (payload: PresenceUpdatePayload) => {
+      if (payload.boardId === boardId) setUsers(payload.users);
+    };
+    socket.on('presence:update', onUpdate);
+
+    return () => {
+      socket.off('presence:update', onUpdate);
+      setUsers([]);
+    };
+  }, [socket, boardId]);
+
+  return users;
+}

--- a/src/app/hooks/useTasks.ts
+++ b/src/app/hooks/useTasks.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { startTransition, useCallback, useOptimistic, useRef, useState } from 'react';
+import { startTransition, useCallback, useEffect, useOptimistic, useRef, useState } from 'react';
 import { useAuthToken } from '../lib/auth/useAuthToken';
+import { useSocket } from '../lib/SocketContext';
 import {
   getTasksByBoard,
   createTask as apiCreateTask,
@@ -13,8 +14,10 @@ import {
   updateComment as apiUpdateComment,
   removeComment as apiRemoveComment,
   adaptBackendTask,
+  type BackendTask,
 } from '../lib/api/tasks';
 import type { Task, Status } from '@/types/task';
+import type { TaskDeletedPayload } from '../types/socket';
 
 // Fields the caller provides when creating a task
 export type CreateTaskFields = Pick<
@@ -86,6 +89,51 @@ export function useTasks(boardId: string | null) {
       setLoading(false);
     }
   }, [getToken, boardId]);
+
+  //  Realtime sync, join the board's room and merge broadcast task events
+  // into serverTasks. Upsert-by-id/filter-by-id makes this idempotent, so a
+  // broadcast echo of this client's own optimistic REST-driven change just
+  // re-applies harmlessly instead of duplicating or erroring.
+
+  const { socket } = useSocket();
+
+  useEffect(() => {
+    if (!socket || !boardId) return;
+
+    // Re-emitted on every (re)connect too. The server drops room membership
+    // on disconnect, so a network blip would otherwise silently stop updates.
+    const join = () => socket.emit('join-board', { boardId });
+
+    join();
+    socket.on('connect', join);
+
+    const upsertTask = (backendTask: BackendTask) => {
+      const incomingTask = adaptBackendTask(backendTask);
+
+      setServerTasks(prevTasks => {
+        const existingIndex = prevTasks.findIndex(existingTask => existingTask.id === incomingTask.id);
+        return existingIndex === -1
+          ? [...prevTasks, incomingTask]
+          : prevTasks.map(existingTask => (existingTask.id === incomingTask.id ? incomingTask : existingTask));
+      });
+    };
+
+    const removeTask = ({ id }: TaskDeletedPayload) => {
+      setServerTasks(prev => prev.filter(prevTask => prevTask.id !== id));
+    };
+
+    socket.on('task:created', upsertTask);
+    socket.on('task:updated', upsertTask);
+    socket.on('task:deleted', removeTask);
+
+    return () => {
+      socket.off('connect', join);
+      socket.off('task:created', upsertTask);
+      socket.off('task:updated', upsertTask);
+      socket.off('task:deleted', removeTask);
+      socket.emit('leave-board', { boardId });
+    };
+  }, [socket, boardId]);
 
   // Create
 

--- a/src/app/lib/SocketContext.tsx
+++ b/src/app/lib/SocketContext.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { useAuth } from '@clerk/nextjs';
+import { getSocket, disconnectSocket, type AppSocket } from './socket';
+import { useAuthToken } from './auth/useAuthToken';
+
+type SocketStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';
+
+interface SocketContextValue {
+  socket: AppSocket | null;
+  status: SocketStatus;
+}
+
+const SocketContext = createContext<SocketContextValue | null>(null);
+
+export function SocketProvider({ children }: { children: ReactNode }) {
+  const { isSignedIn } = useAuth();
+  const getToken = useAuthToken();
+  const [socket, setSocket] = useState<AppSocket | null>(null);
+  const [status, setStatus] = useState<SocketStatus>('idle');
+
+  useEffect(() => {
+    if (!isSignedIn) {
+      disconnectSocket();
+      setSocket(null);
+      setStatus('idle');
+      return;
+    }
+
+    let appSocket: AppSocket;
+    try {
+      appSocket = getSocket(getToken);
+    } catch {
+      setStatus('error');
+      return;
+    }
+
+    const handleConnect = () => setStatus('connected');
+    const handleDisconnect = () => setStatus('disconnected');
+    const handleConnectError = () => setStatus('error');
+
+    appSocket.on('connect', handleConnect);
+    appSocket.on('disconnect', handleDisconnect);
+    appSocket.on('connect_error', handleConnectError);
+
+    setSocket(appSocket);
+    if (!appSocket.connected) {
+      setStatus('connecting');
+      appSocket.connect();
+    }
+
+    return () => {
+      appSocket.off('connect', handleConnect);
+      appSocket.off('disconnect', handleDisconnect);
+      appSocket.off('connect_error', handleConnectError);
+    };
+  }, [isSignedIn, getToken]);
+
+  // Tear down the connection on true unmount (e.g. whole app unmounting) 
+  // the sign-out case is already handled above when `isSignedIn` flips false.
+  useEffect(() => {
+    return () => disconnectSocket();
+  }, []);
+
+  return (
+    <SocketContext.Provider value={{ socket, status }}>
+      {children}
+    </SocketContext.Provider>
+  );
+}
+
+export function useSocket() {
+  const ctx = useContext(SocketContext);
+  if (!ctx) throw new Error('useSocket must be used inside SocketProvider');
+  return ctx;
+}

--- a/src/app/lib/socket.ts
+++ b/src/app/lib/socket.ts
@@ -1,0 +1,39 @@
+import { io, type Socket } from 'socket.io-client';
+import type { ClientToServerEvents, ServerToClientEvents } from '../types/socket';
+
+const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL;
+
+export type AppSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+let socket: AppSocket | null = null;
+
+// Lazy singleton —> connecting is the caller's responsibility (call `.connect()`
+// once auth is ready), so a signed-out user never opens a socket at all.
+export function getSocket(getToken: () => Promise<string>): AppSocket {
+  if (socket) return socket;
+
+  if (!SOCKET_URL) {
+    throw new Error(
+      'NEXT_PUBLIC_SOCKET_URL is not set — cannot connect to the realtime server.'
+    );
+  }
+
+  socket = io(SOCKET_URL, {
+    autoConnect: false,
+    // Re-invoked on every (re)connection attempt, so a token that expired
+    // since the last connect is refreshed automatically on reconnect.
+    auth: (authCallback) => {
+      getToken()
+        .then((token) => authCallback({ token }))
+        .catch(() => authCallback({}));
+    },
+  });
+
+  return socket;
+}
+
+export function disconnectSocket() {
+  if (!socket) return;
+  socket.disconnect();
+  socket = null;
+}

--- a/src/app/types/socket.ts
+++ b/src/app/types/socket.ts
@@ -1,0 +1,40 @@
+import type { BackendTask } from '../lib/api/tasks';
+
+// ── Event contract shared with the (future) backend Socket.io gateway ──────────
+// Rooms are scoped per board: `board:{boardId}`. Auth happens once at the
+// handshake (Clerk JWT via the `auth` option), so client → server payloads
+// never need to carry user identity themselves.
+
+export interface JoinBoardPayload {
+  boardId: string;
+}
+
+export interface LeaveBoardPayload {
+  boardId: string;
+}
+
+export interface TaskDeletedPayload {
+  id: string;
+}
+
+export interface PresenceUser {
+  id: string;
+  name: string;
+}
+
+export interface PresenceUpdatePayload {
+  boardId: string;
+  users: PresenceUser[];
+}
+
+export interface ServerToClientEvents {
+  'task:created': (task: BackendTask) => void;
+  'task:updated': (task: BackendTask) => void;
+  'task:deleted': (payload: TaskDeletedPayload) => void;
+  'presence:update': (payload: PresenceUpdatePayload) => void;
+}
+
+export interface ClientToServerEvents {
+  'join-board': (payload: JoinBoardPayload) => void;
+  'leave-board': (payload: LeaveBoardPayload) => void;
+}

--- a/src/app/ui/Avatar.tsx
+++ b/src/app/ui/Avatar.tsx
@@ -39,12 +39,22 @@ export function Avatar({ name, size = 24, tone = undefined }: { name: string; si
   );
 }
 
-export function AvatarStack({ names, size = 22, max = 3 }: { names: string[]; size?: number; max?: number }) {
+export function AvatarStack({
+  names,
+  size = 22,
+  max = 3,
+  label: labelPrefix = "Assigned to",
+}: {
+  names: string[];
+  size?: number;
+  max?: number;
+  label?: string;
+}) {
   const shown = names.slice(0, max);
   const extra = names.length - shown.length;
   const label = extra > 0
-    ? `Assigned to ${shown.join(", ")} and ${extra} more`
-    : `Assigned to ${names.join(", ")}`;
+    ? `${labelPrefix} ${shown.join(", ")} and ${extra} more`
+    : `${labelPrefix} ${names.join(", ")}`;
 
   return (
     <div

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,14 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/app/*"]
+    },
     "plugins": [
       {
         "name": "next"
@@ -27,7 +31,8 @@
     "next-env.d.ts",
     ".next/types/**/*.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
### Adds the frontend Socket.io integration for issue #9

## Summary of what's changed:

- [x]  connects to a realtime server
- [x] listens for task changes to keep the board live
- [x] shows who's viewing each board.


# More details 
- `types/socket.ts`:  event contract (join-board/leave-board, task:created/updated/deleted, presence:update) for the backend gateway to implement against (up next)
-` lib/socket.ts` + `lib/SocketContext.tsx`: lazy singleton connection, authenticated via Clerk JWT, wired into the app layout
- `useTasks`: joins/leaves the board's room and merges live task events into board state
- `useBoardPresence `+ `BoardHeader`: shows online users per board
- Removes the old dead `socket.emit('update-tasks')` stub
- Adds `NEXT_PUBLIC_SOCKET_URL` to `.env.local.example`

closes #9 